### PR TITLE
BUGFIX: do not fieldify methods

### DIFF
--- a/microdantic/main.py
+++ b/microdantic/main.py
@@ -136,6 +136,19 @@ class ModelWithDiscriminatedUnion(BaseModel):
     )
 
 
+@register
+class ModelWithMethod(BaseModel):
+    a: int = Field(int)
+    b: int = Field(int)
+
+    @property
+    def highest(self):
+        return max(self.a, self.b)
+
+    def get_highest(self):
+        return max(self.a, self.b)
+
+
 # ========== Test Functions ==========
 def test_construction_and_default_values():
     print("...default apple")
@@ -403,6 +416,17 @@ def test_auto_discrimination_from_base_model():
 
     assert isinstance(ma_deserialized.nested_model, NestedModelA)
     assert isinstance(mb_deserialized.nested_model, NestedModelB)
+
+
+def test_model_with_methods():
+    print("...Instantiate model object")
+    model = ModelWithMethod(a=2, b=5)
+
+    print("...checking method")
+    assert model.get_highest() == 5
+
+    print("...checking property")
+    assert model.highest == 5, f"model.highest is {model.highest}"
 
 
 # ========== Test Execution ==========

--- a/microdantic/main.py
+++ b/microdantic/main.py
@@ -37,6 +37,7 @@ running `poetry run tests` inside the project directory.
 
 import json
 import time
+from functools import cached_property
 
 from microdantic import (
     BaseModel,
@@ -141,12 +142,20 @@ class ModelWithMethod(BaseModel):
     a: int = Field(int)
     b: int = Field(int)
 
-    @property
-    def highest(self):
-        return max(self.a, self.b)
-
     def get_highest(self):
         return max(self.a, self.b)
+
+    @property
+    def highest(self):
+        return self.get_highest()
+
+    @cached_property
+    def cached_highest(self):
+        return self.get_highest()
+
+    @staticmethod
+    def something_static():
+        return "something static"
 
 
 # ========== Test Functions ==========
@@ -423,10 +432,16 @@ def test_model_with_methods():
     model = ModelWithMethod(a=2, b=5)
 
     print("...checking method")
-    assert model.get_highest() == 5
+    assert model.get_highest() == 5, f"{model.get_highest()} != 5"
 
     print("...checking property")
-    assert model.highest == 5, f"model.highest is {model.highest}"
+    assert model.highest == 5, f"{model.highest} != 5"
+
+    print("...checking cached_property")
+    assert model.cached_highest == 5, f"{model.cached_highest} != 5"
+
+    print("...checking static method")
+    assert model.something_static(), f"{model.something_static()} != 'something static'"
 
 
 # ========== Test Execution ==========

--- a/microdantic/main.py
+++ b/microdantic/main.py
@@ -37,7 +37,11 @@ running `poetry run tests` inside the project directory.
 
 import json
 import time
-from functools import cached_property
+
+try:
+    from functools import cached_property
+except (ImportError, AttributeError):
+    from microdantic import cached_property
 
 from microdantic import (
     BaseModel,
@@ -376,7 +380,10 @@ def test_nested_union():
 
 
 def test_is_discriminated_match():
-    from microdantic.microdantic import _is_discriminated_match
+    try:
+        from microdantic.microdantic import _is_discriminated_match
+    except ImportError:
+        from microdantic import _is_discriminated_match
 
     print("...Correctly identify matches")
     assert _is_discriminated_match("internal_key", "A", DiscriminatedModelA)

--- a/microdantic/microdantic.py
+++ b/microdantic/microdantic.py
@@ -24,7 +24,22 @@ SOFTWARE.
 
 __version__ = "v0.3.1"
 import json
-from functools import cached_property
+
+try:
+    from functools import cached_property
+except (ImportError, AttributeError):
+    # Fallback for CircuitPython or MicroPython
+    class cached_property:  # noqa
+        def __init__(self, func):
+            self.func = func
+            self.attr_name = func.__name__
+
+        def __get__(self, instance, owner):
+            if instance is None:
+                return self
+            value = self.func(instance)
+            setattr(instance, self.attr_name, value)
+            return value
 
 
 class _SpecialType:

--- a/microdantic/microdantic.py
+++ b/microdantic/microdantic.py
@@ -24,6 +24,7 @@ SOFTWARE.
 
 __version__ = "v0.3.1"
 import json
+from functools import cached_property
 
 
 class _SpecialType:
@@ -503,8 +504,13 @@ class BaseModel:
         # same type as the default value, rather than the type of the
         # annotation.
         new_fields = dict()
+        descriptor_types = (Field, property, classmethod, staticmethod, cached_property)
         for name, field in cls.__dict__.items():
-            if not name.startswith("_") and not isinstance(field, Field):
+            if (
+                not name.startswith("_")
+                and not callable(field)
+                and not isinstance(field, descriptor_types)
+            ):
                 new_fields[name] = Field(data_type=type(field), default=field)
 
         for name, field_obj in new_fields.items():


### PR DESCRIPTION
The register method was incorrectly taking all methods, properties, and other members that were already some king of descriptor or callable and wrapping them in the custom Field() descriptor. These elements are now excluded from this behavior.